### PR TITLE
Kue Daemon as env var

### DIFF
--- a/src/module/services/kue/kue.service.ts
+++ b/src/module/services/kue/kue.service.ts
@@ -54,13 +54,15 @@ export class KueService {
         if (!this.queues[queueName]) {
             this.queues[queueName] = this.createQueue(queueName);
         }
-        this.queues[queueName].process(metadata.name, concurrency, async (j, d) => {
-            try {
-                await Promise.resolve(task.call(ctrl, j, d));
-            } catch (err) {
-                d(err);
-            }
-        });
+        if ((eval(process.env.KUE_START_PROCESSING) || true)) {
+            this.queues[queueName].process(metadata.name, concurrency, async (j, d) => {
+                try {
+                    await Promise.resolve(task.call(ctrl, j, d));
+                } catch (err) {
+                    d(err);
+                }
+            });
+        }
         this.tasks[metadata.name] = metadata;
     }
 


### PR DESCRIPTION
Imagine the following situation with a monolite:
You want a container to only run your API and should no process anything about Kue, only register tasks. And another container that runs Kue Daemon and process all your queues.

Setting this variable as `KUE_START_PROCESSING` as false will prevent to run Kue Daemon on API container.